### PR TITLE
Fix version selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,8 @@ jobs:
 
       - name: Install pip and setuptools
         run: |
-          python -m pip install --upgrade pip==23.0.0
-          python -m pip install --upgrade pip==23.0.0
+          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade pip
 
       - name: Install system dependencies
         run: |
@@ -99,8 +99,10 @@ jobs:
       # install package
       - name: Install the package
         run: |
+          simulatorVersion=$(jq -r '.version' biosimulators.json)
+          # AMICI has to be installed before biosimulators_amici to get the right version
+          AMICI_PARALLEL_COMPILE="" python -m pip install amici==$simulatorVersion
           python -m pip install .[all]
-          AMICI_PARALLEL_COMPILE="" python -m pip install amici
 
       #############################################
       ## Lint
@@ -178,7 +180,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
-          file: ./coverage.xml
+          files: ./coverage.xml
 
       #############################################
       ## Compile documentation

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.11-slim-bookworm
 
 ARG VERSION="0.1.22"
-ARG SIMULATOR_VERSION="0.24.0"
+ARG SIMULATOR_VERSION="0.34.0"
 
 # metadata
 LABEL \
@@ -47,11 +47,11 @@ RUN apt-get update -y \
 
 # Copy code for command-line interface into image and install it
 COPY . /root/Biosimulators_AMICI
-RUN pip install pip==23.0.1
-RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_BIOSIMULATORS_AMICI=${VERSION} pip install /root/Biosimulators_AMICI \
+RUN python -m pip install -U setuptools pip
+# AMICI has to be installed before biosimulators_amici to get the right version
+RUN AMICI_PARALLEL_COMPILE="" python -m pip install amici==${SIMULATOR_VERSION}
+RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_BIOSIMULATORS_AMICI=${VERSION} python -m pip install /root/Biosimulators_AMICI \
     && rm -rf /root/Biosimulators_AMICI
-#RUN pip install sympy /root/Biosimulators_AMICI amici==${SIMULATOR_VERSION} \
-#    && rm -rf /root/Biosimulators_AMICI
 ENV VERBOSE=0 \
     MPLBACKEND=PDF \
     AMICI_PARALLEL_COMPILE=""

--- a/biosimulators.json
+++ b/biosimulators.json
@@ -1,7 +1,7 @@
 {
   "id": "amici",
   "name": "AMICI",
-  "version": "0.24.0",
+  "version": "0.34.0",
   "description": "AMICI provides an interface for the SUNDIALS solvers CVODES (for ordinary differential equations) and IDAS (for algebraic differential equations).",
   "urls": [
     {
@@ -10,7 +10,7 @@
     }
   ],
   "image": {
-    "url": "ghcr.io/biosimulators/biosimulators_amici/amici:0.24.0",
+    "url": "ghcr.io/biosimulators/biosimulators_amici/amici:0.34.0",
     "format": {
       "namespace": "EDAM",
       "id": "format_3973",


### PR DESCRIPTION
Previously, the simulator version argument was ignored and always the latest amici version was installed.
