### PR TITLE
Disable actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,13 +75,13 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Setup pip cache
-        uses: actions/cache@v3
-        with:
-          path: /opt/hostedtoolcache/Python
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements.optional.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+#      - name: Setup pip cache
+#        uses: actions/cache@v3
+#        with:
+#          path: /opt/hostedtoolcache/Python
+#          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements.optional.txt') }}
+#          restore-keys: |
+#            ${{ runner.os }}-pip-
 
       - name: Install pip and setuptools
         run: |


### PR DESCRIPTION
Disable caching ` /opt/hostedtoolcache/Python` which causes problems in combination with setup-python and upgrading pip.